### PR TITLE
feature: nested keys

### DIFF
--- a/.mocharc.json
+++ b/.mocharc.json
@@ -1,0 +1,5 @@
+{
+  "package": "./package.json",
+  "watch-files": ["test/*.js", "test/**/*.js"],
+  "recursive": true
+}

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ npm i @tutecano1995/knex-cache
 
 ## Example
 
+## Simple keys
 
 ```js
 const knex = require('knex');
@@ -31,4 +32,30 @@ await knexInstance.select().from('users').cache('users'); // Should not execute 
 await knexInstance('users').update({username: 'tutecano22'}).where({id: 22}).invalidate('users'); // Invalidate users
 
 await knexInstance.select().from('users').cache('users'); // Should execute the query
+```
+
+
+## Nested keys
+
+```js
+const knex = require('knex');
+const knexCache = require('@tutecano1995/knex-cache');
+
+knexCache(knex);
+
+await knexInstance.select().from('users').cache('users'); // Should execute the query
+await knexInstance.select().from('users').where({id: 22}).cache('users.22'); // Should execute the query and cache the chid key
+await knexInstance.select().from('users').where({id: 22}).cache('users.15'); // Should execute the query and cache the chid key
+
+await knexInstance('users').update({name: 'test'}).invalidate('users'); // Invalidate users and all children
+
+await knexInstance.select().from('users').cache('users'); // Should execute the query
+await knexInstance.select().from('users').where({id: 22}).cache('users.22'); // Should execute the query and cache the chid key
+await knexInstance.select().from('users').where({id: 22}).cache('users.15'); // Should execute the query and cache the chid key
+
+await knexInstance('users').update({name: 'test'}).invalidate('users', {exact: true}); // Invalidate only users
+
+await knexInstance.select().from('users').cache('users'); // Should execute the query
+await knexInstance.select().from('users').where({id: 22}).cache('users.22'); // Should not execute the query and use cache
+await knexInstance.select().from('users').where({id: 22}).cache('users.15'); // Should not execute the query and use cache
 ```

--- a/lib/commands.js
+++ b/lib/commands.js
@@ -1,0 +1,27 @@
+'use strict';
+
+const knexCacheUtils = require('./utils');
+
+function cache(cache, knexQuery, key) {
+  let data = knexCacheUtils.get(cache, key);
+  if(data) {
+    return Promise.resolve(data);
+  }
+  return knexQuery.then(data => {
+    knexCacheUtils.set(cache, key, data);
+    return data;
+  });
+}
+
+function invalidate(cache, knexQuery, key, { exact = false } = {}) {
+  if(knexCacheUtils.get(cache, key)) {
+    knexCacheUtils.unset(cache, key, { exact });
+  }
+  return knexQuery;
+}
+
+module.exports = {
+  cache,
+  invalidate
+};
+

--- a/lib/knexCache.js
+++ b/lib/knexCache.js
@@ -1,15 +1,36 @@
 'use strict';
 
+const _ = require('lodash');
+
+function get(cache, key) {
+  const fields = key.split('.');
+  const cacheKey = fields.join('.children.');
+  return _.get(cache, `${cacheKey}.value`); // Get value
+}
+
+function set(cache, key, data) {
+  const fields = key.split('.');
+  const cacheKey = fields.join('.children.');
+  _.set(cache, `${cacheKey}.value`, data); // Set value
+}
+
+function unset(cache, key) {
+  const fields = key.split('.');
+  const cacheKey = fields.join('.children.');
+  _.unset(cache, `${cacheKey}`); // Remove both children and value
+}
+
 module.exports = function knexCache(knex) {
   let cache = {};
 
   knex.QueryBuilder.extend('cache', async function (key) {
     try {
-      if(cache[key]) { 
-        return cache[key];
+      let data = get(cache, key);
+      if(data) {
+        return data;
       }
-      const data = await this;
-      cache[key] = data;
+      data = await this;
+      set(cache, key, data);
       return data;
     } catch (e) {
       throw new Error(e);
@@ -18,8 +39,8 @@ module.exports = function knexCache(knex) {
 
   knex.QueryBuilder.extend('invalidate', async function (key) {
     try {
-      if(cache[key]) { 
-        delete cache[key];
+      if(get(cache, key)) {
+        unset(cache, key);
       }
       const data = await this;
       return data

--- a/lib/knexCache.js
+++ b/lib/knexCache.js
@@ -1,47 +1,16 @@
 'use strict';
 
 const _ = require('lodash');
-
-function get(cache, key) {
-  const fields = key.split('.');
-  const cacheKey = fields.join('.children.');
-  return _.get(cache, `${cacheKey}.value`); // Get value
-}
-
-function set(cache, key, data) {
-  const fields = key.split('.');
-  const cacheKey = fields.join('.children.');
-  _.set(cache, `${cacheKey}.value`, data); // Set value
-}
-
-function unset(cache, key, { exact } = {}) {
-  const fields = key.split('.');
-  let cacheKey = fields.join('.children.');
-  // If exact is true remove only value
-  if (exact) {
-    cacheKey = `${cacheKey}.value`;
-  }
-  _.unset(cache, `${cacheKey}`);
-}
+const commands = require('./commands');
 
 module.exports = function knexCache(knex) {
   let cache = {};
 
   knex.QueryBuilder.extend('cache', function (key) {
-    let data = get(cache, key);
-    if(data) {
-      return Promise.resolve(data);
-    }
-    return this.then(data => {
-      set(cache, key, data);
-      return data;
-    });
+    return commands.cache(cache, this, key);
   });
 
-  knex.QueryBuilder.extend('invalidate', function (key, { exact = false } = {}) {
-    if(get(cache, key)) {
-      unset(cache, key, { exact });
-    }
-    return this;
+  knex.QueryBuilder.extend('invalidate', function (key, options={}) {
+    return commands.invalidate(cache, this, key, options);
   });
 }

--- a/lib/knexCache.js
+++ b/lib/knexCache.js
@@ -14,38 +14,34 @@ function set(cache, key, data) {
   _.set(cache, `${cacheKey}.value`, data); // Set value
 }
 
-function unset(cache, key) {
+function unset(cache, key, { exact } = {}) {
   const fields = key.split('.');
-  const cacheKey = fields.join('.children.');
-  _.unset(cache, `${cacheKey}`); // Remove both children and value
+  let cacheKey = fields.join('.children.');
+  // If exact is true remove only value
+  if (exact) {
+    cacheKey = `${cacheKey}.value`;
+  }
+  _.unset(cache, `${cacheKey}`);
 }
 
 module.exports = function knexCache(knex) {
   let cache = {};
 
-  knex.QueryBuilder.extend('cache', async function (key) {
-    try {
-      let data = get(cache, key);
-      if(data) {
-        return data;
-      }
-      data = await this;
+  knex.QueryBuilder.extend('cache', function (key) {
+    let data = get(cache, key);
+    if(data) {
+      return Promise.resolve(data);
+    }
+    return this.then(data => {
       set(cache, key, data);
       return data;
-    } catch (e) {
-      throw new Error(e);
-    }
+    });
   });
 
-  knex.QueryBuilder.extend('invalidate', async function (key) {
-    try {
-      if(get(cache, key)) {
-        unset(cache, key);
-      }
-      const data = await this;
-      return data
-    } catch (e) {
-      throw new Error(e);
+  knex.QueryBuilder.extend('invalidate', function (key, { exact = false } = {}) {
+    if(get(cache, key)) {
+      unset(cache, key, { exact });
     }
+    return this;
   });
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,0 +1,31 @@
+'use strict';
+
+const _ = require('lodash');
+
+function get(cache, key) {
+  const fields = key.split('.');
+  const cacheKey = fields.join('.children.');
+  return _.get(cache, `${cacheKey}.value`); // Get value
+}
+
+function set(cache, key, data) {
+  const fields = key.split('.');
+  const cacheKey = fields.join('.children.');
+  _.setWith(cache, `${cacheKey}.value`, data, Object); // Set value
+}
+
+function unset(cache, key, { exact } = {}) {
+  const fields = key.split('.');
+  let cacheKey = fields.join('.children.');
+  // If exact is true remove only value
+  if (exact) {
+    cacheKey = `${cacheKey}.value`;
+  }
+  _.unset(cache, `${cacheKey}`);
+}
+
+module.exports = {
+  get,
+  set,
+  unset
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tutecano1995/knex-cache",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tutecano1995/knex-cache",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "ISC",
       "dependencies": {
         "knex": "^2.4.2",
@@ -20,6 +20,8 @@
         "mocha": "^10.2.0",
         "mock-knex": "^0.4.12",
         "nyc": "^15.1.0",
+        "sinon": "^15.0.2",
+        "sinon-chai": "^3.7.0",
         "typescript": "^4.9.5"
       }
     },
@@ -564,6 +566,59 @@
         "@jridgewell/resolve-uri": "3.1.0",
         "@jridgewell/sourcemap-codec": "1.4.14"
       }
+    },
+    "node_modules/@sinonjs/commons": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.0.tgz",
+      "integrity": "sha512-jXBtWAF4vmdNmZgD5FoKsVLv3rPgDnLgPbU84LIJ3otV44vJlDRokVng5v8NFJdCf/da9legHcKaRuZs4L7faA==",
+      "dev": true,
+      "dependencies": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/fake-timers": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.0.2.tgz",
+      "integrity": "sha512-SwUDyjWnah1AaNl7kxsa7cfLhlTYoiyhDAIgyh+El30YvXs/o7OLXpYH88Zdhyx9JExKrmHDJ+10bwIcY80Jmw==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^2.0.0"
+      }
+    },
+    "node_modules/@sinonjs/fake-timers/node_modules/@sinonjs/commons": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-2.0.0.tgz",
+      "integrity": "sha512-uLa0j859mMrg2slwQYdO/AkrOfmH+X6LTVmNTS9CqexuE2IvVORIkSpJLqePAbEnKJ77aMmCwr1NUZ57120Xcg==",
+      "dev": true,
+      "dependencies": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/samsam": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-7.0.1.tgz",
+      "integrity": "sha512-zsAk2Jkiq89mhZovB2LLOdTCxJF4hqqTToGP0ASWlhp4I1hqOjcfmZGafXntCN7MDC6yySH0mFHrYtHceOeLmw==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^2.0.0",
+        "lodash.get": "^4.4.2",
+        "type-detect": "^4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/samsam/node_modules/@sinonjs/commons": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-2.0.0.tgz",
+      "integrity": "sha512-uLa0j859mMrg2slwQYdO/AkrOfmH+X6LTVmNTS9CqexuE2IvVORIkSpJLqePAbEnKJ77aMmCwr1NUZ57120Xcg==",
+      "dev": true,
+      "dependencies": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/text-encoding": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.2.tgz",
+      "integrity": "sha512-sXXKG+uL9IrKqViTtao2Ws6dy0znu9sOaP1di/jKGW1M6VssO8vlpXCQcpZ+jisQ1tTFAC5Jo/EOzFbggBagFQ==",
+      "dev": true
     },
     "node_modules/@tsconfig/node18": {
       "version": "1.0.1",
@@ -1520,6 +1575,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
+      "dev": true
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -1674,6 +1735,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/just-extend": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
+      "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==",
+      "dev": true
+    },
     "node_modules/knex": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/knex/-/knex-2.4.2.tgz",
@@ -1748,6 +1815,12 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
       "integrity": "sha512-uHaJFihxmJcEX3kT4I23ABqKKalJ/zDrDg0lsFtc1h+3uw49SIJ5beyhx5ExVRti3AvKoOJngIj7xz3oylPdWQ==",
+      "dev": true
+    },
+    "node_modules/lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
       "dev": true
     },
     "node_modules/log-symbols": {
@@ -1895,6 +1968,28 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/nise": {
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-5.1.4.tgz",
+      "integrity": "sha512-8+Ib8rRJ4L0o3kfmyVCL7gzrohyDe0cMFTBa2d364yIrEGMEoetznKJx899YxjybU6bL9SQkYPSBBs1gyYs8Xg==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^2.0.0",
+        "@sinonjs/fake-timers": "^10.0.2",
+        "@sinonjs/text-encoding": "^0.7.1",
+        "just-extend": "^4.0.2",
+        "path-to-regexp": "^1.7.0"
+      }
+    },
+    "node_modules/nise/node_modules/@sinonjs/commons": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-2.0.0.tgz",
+      "integrity": "sha512-uLa0j859mMrg2slwQYdO/AkrOfmH+X6LTVmNTS9CqexuE2IvVORIkSpJLqePAbEnKJ77aMmCwr1NUZ57120Xcg==",
+      "dev": true,
+      "dependencies": {
+        "type-detect": "4.0.8"
       }
     },
     "node_modules/node-preload": {
@@ -2212,6 +2307,15 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
+    },
+    "node_modules/path-to-regexp": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+      "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+      "dev": true,
+      "dependencies": {
+        "isarray": "0.0.1"
+      }
     },
     "node_modules/pathval": {
       "version": "1.1.1",
@@ -2593,6 +2697,55 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true
+    },
+    "node_modules/sinon": {
+      "version": "15.0.2",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-15.0.2.tgz",
+      "integrity": "sha512-PCVP63XZkg0/LOqQH5rEU4LILuvTFMb5tNxTHfs6VUMNnZz2XrnGSTZbAGITjzwQWbl/Bl/8hi4G3zZWjyBwHg==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.0",
+        "@sinonjs/fake-timers": "^10.0.2",
+        "@sinonjs/samsam": "^7.0.1",
+        "diff": "^5.1.0",
+        "nise": "^5.1.4",
+        "supports-color": "^7.2.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/sinon"
+      }
+    },
+    "node_modules/sinon-chai": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-3.7.0.tgz",
+      "integrity": "sha512-mf5NURdUaSdnatJx3uhoBOrY9dtL19fiOtAdT1Azxg3+lNJFiuN0uzaU3xX1LeAfL17kHQhTAJgpsfhbMJMY2g==",
+      "dev": true,
+      "peerDependencies": {
+        "chai": "^4.0.0",
+        "sinon": ">=4.0.0"
+      }
+    },
+    "node_modules/sinon/node_modules/diff": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.1.0.tgz",
+      "integrity": "sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/sinon/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/source-map": {
       "version": "0.6.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,20 +1,22 @@
 {
-  "name": "knex-cache",
-  "version": "1.0.0",
+  "name": "@tutecano1995/knex-cache",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "knex-cache",
-      "version": "1.0.0",
+      "name": "@tutecano1995/knex-cache",
+      "version": "1.0.1",
       "license": "ISC",
       "dependencies": {
         "knex": "^2.4.2",
+        "lodash": "^4.17.21",
         "pg": "^8.9.0"
       },
       "devDependencies": {
         "@tsconfig/node18": "^1.0.1",
         "chai": "^4.3.7",
+        "decache": "^4.6.1",
         "mocha": "^10.2.0",
         "mock-knex": "^0.4.12",
         "nyc": "^15.1.0",
@@ -760,6 +762,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/callsite": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
+      "integrity": "sha512-0vdNRFXn5q+dtOqjfFtmtlI9N2eVZ7LMyEV2iKC5mEEFvSg/69Ml6b/WU2qF8W1nLRa0wiSrDT3Y5jOHZCwKPQ==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/camelcase": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
@@ -967,6 +978,15 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/decache": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/decache/-/decache-4.6.1.tgz",
+      "integrity": "sha512-ohApBM8u9ygepJCjgBrEZSSxPjc0T/PJkD+uNyxXPkqudyUpdXpwJYp0VISm2WrPVzASU6DZyIi6BWdyw7uJ2Q==",
+      "dev": true,
+      "dependencies": {
+        "callsite": "^1.0.0"
       }
     },
     "node_modules/decamelize": {

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "@tutecano1995/knex-cache",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "",
   "main": "./lib/knexCache.js",
   "scripts": {
-    "test": "nyc --reporter=lcov --reporter=text mocha ./test/**.test.js"
+    "test": "nyc --reporter=lcov --reporter=text mocha --config=.mocharc.json"
   },
   "author": "",
   "license": "ISC",
@@ -20,6 +20,8 @@
     "mocha": "^10.2.0",
     "mock-knex": "^0.4.12",
     "nyc": "^15.1.0",
+    "sinon": "^15.0.2",
+    "sinon-chai": "^3.7.0",
     "typescript": "^4.9.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tutecano1995/knex-cache",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "",
   "main": "./lib/knexCache.js",
   "scripts": {
@@ -10,11 +10,13 @@
   "license": "ISC",
   "dependencies": {
     "knex": "^2.4.2",
+    "lodash": "^4.17.21",
     "pg": "^8.9.0"
   },
   "devDependencies": {
     "@tsconfig/node18": "^1.0.1",
     "chai": "^4.3.7",
+    "decache": "^4.6.1",
     "mocha": "^10.2.0",
     "mock-knex": "^0.4.12",
     "nyc": "^15.1.0",

--- a/test/integration/knexCache.test.js
+++ b/test/integration/knexCache.test.js
@@ -1,4 +1,4 @@
-const knexCache = require('../lib/knexCache');
+const knexCache = require('../../lib/knexCache');
 const knexMock = require('mock-knex');
 const { expect } = require('chai');
 const decache = require('decache');

--- a/test/knexCache.test.js
+++ b/test/knexCache.test.js
@@ -1,24 +1,24 @@
-const knex = require('knex');
 const knexCache = require('../lib/knexCache');
 const knexMock = require('mock-knex');
 const { expect } = require('chai');
+const decache = require('decache');
 
 describe('#knexCache', () => {
   let knexInstance;
   let tracker;
   let dbQueries;
-
-  before(() => {
-    knexCache(knex);
-  })
+  let knex;
 
   beforeEach(() => {
     dbQueries = {};
 
+    knex = require('knex');
+    knexCache(knex);
+
     knexInstance = knex({
       client: 'pg'
     });
-    
+
     knexMock.mock(knexInstance);
     tracker = knexMock.getTracker();
     tracker.install();
@@ -33,25 +33,78 @@ describe('#knexCache', () => {
   afterEach(() => {
     knexMock.unmock(knexInstance);
     tracker.uninstall();
+    decache('knex');
   })
 
-  describe('when caching query', () => {
-    beforeEach(async () => {
-      await knexInstance.select().from('users').cache('users'); // Should execute the query
-      await knexInstance.select().from('users').cache('users'); // Should not execute the query and use cache
+  describe('#cache', () => {
+    describe('simple key', () => {
+      beforeEach(async () => {
+        await knexInstance.select().from('users').cache('users'); // Should execute the query
+        await knexInstance.select().from('users').cache('users'); // Should not execute the query and use cache
+      });
+
+      it('should execute the query once', () => expect(dbQueries['select * from "users"']).be.equal(1));
     });
 
-    it('should execute the query once', () => expect(dbQueries['select * from "users"']).be.equal(1));
-
-    describe('when invalidating query', () => {
+    describe('nested keys', () => {
       beforeEach(async () => {
+        await knexInstance.select().from('users').cache('users'); // Should execute the query
+        await knexInstance.select().from('users').cache('users'); // Should not execute the query and use cache
+        await knexInstance.select().from('users').where({id: 22}).cache('users.22'); // Should execute the query
+        await knexInstance.select().from('users').where({id: 22}).cache('users.22'); // Should not execute the query and use cache
+      });
+
+      it('should execute the parent query once', () => expect(dbQueries['select * from "users"']).be.equal(1));
+
+      it('should execute the child query once', () => expect(dbQueries['select * from "users" where "id" = $1']).be.equal(1));
+    });
+  });
+
+  describe('#invalidate', () => {
+    describe('simple key', () => {
+      beforeEach(async () => {
+        await knexInstance.select().from('users').cache('users'); // Should execute the query
         await knexInstance('users').update({username: 'tutecano22'}).invalidate('users');
         await knexInstance.select().from('users').cache('users'); // Should execute the query after invalidation
       });
 
       it('should execute the update', () => expect(dbQueries['update "users" set "username" = $1']).be.equal(1));
 
-      it('should execute the query after invalidation', () => expect(dbQueries['select * from "users"']).be.equal(1));
+      it('should execute the query after invalidation', () => expect(dbQueries['select * from "users"']).be.equal(2));
+    });
+
+    describe('nested keys', () => {
+      describe('invalidating parent key', () => {
+        beforeEach(async () => {
+          await knexInstance.select().from('users').cache('users'); // Should execute the query
+          await knexInstance.select().from('users').where({id: 22}).cache('users.22'); // Should execute the query
+          await knexInstance('users').update({username: 'tutecano22'}).invalidate('users');
+          await knexInstance.select().from('users').cache('users'); // Should execute the query after invalidation
+          await knexInstance.select().from('users').where({id: 22}).cache('users.22'); // Should execute the query after invalidation
+        });
+
+        it('should execute the update', () => expect(dbQueries['update "users" set "username" = $1']).be.equal(1));
+
+        it('should execute the parent query twice', () => expect(dbQueries['select * from "users"']).be.equal(2));
+
+        it('should execute the child query twice', () => expect(dbQueries['select * from "users" where "id" = $1']).be.equal(2));
+      });
+
+      describe('invalidating child key', () => {
+        beforeEach(async () => {
+          await knexInstance.select().from('users').cache('users'); // Should execute the query
+          await knexInstance.select().from('users').where({id: 22}).cache('users.22'); // Should execute the query
+          await knexInstance('users').update({username: 'tutecano22'}).where({id: 22}).invalidate('users.22');
+          await knexInstance.select().from('users').cache('users'); // Should not execute the query and use cache
+          await knexInstance.select().from('users').where({id: 22}).cache('users.22'); // Should execute the query after invalidation
+        });
+
+        it('should execute the update', () => expect(dbQueries['update "users" set "username" = $1 where "id" = $2']).be.equal(1));
+
+        it('should execute the parent query once', () => expect(dbQueries['select * from "users"']).be.equal(1));
+
+        it('should execute the child query twice', () => expect(dbQueries['select * from "users" where "id" = $1']).be.equal(2));
+      });
     });
   });
 })

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,0 +1,11 @@
+const chai = require('chai');
+const sinon = require('sinon');
+const sinonChai = require('sinon-chai');
+
+global.should = chai.should();
+
+chai.use(sinonChai);
+
+afterEach(function closeTest() {
+  sinon.restore();
+});

--- a/test/unit/commands.test.js
+++ b/test/unit/commands.test.js
@@ -1,0 +1,90 @@
+'use strict';
+
+const sinon = require('sinon');
+
+const commands = require('../../lib/commands');
+const knexCacheUtils = require('../../lib/utils');
+
+describe('#commands', () => {
+  let cache;
+  let key;
+  let data;
+  let knexQuery;
+
+  beforeEach(() => {
+    cache = {};
+    key = 'key';
+    data = 'data';
+    knexQuery = Promise.resolve(data);
+
+    sinon.stub(knexCacheUtils, 'set');
+    sinon.stub(knexCacheUtils, 'unset');
+    sinon.stub(knexCacheUtils, 'get');
+  });
+
+  describe('#cache', () => {
+    let result;
+
+    describe('when data is already cached', () => {
+      let cachedData;
+
+      beforeEach(async () => {
+        cachedData = 'cachedData';
+        knexCacheUtils.get.returns(cachedData);
+        result = await commands.cache(cache, knexQuery, key);
+      });
+
+      it('should resolve with cached data', () => result.should.be.equal(cachedData));
+
+      it('should get data from cache', () => knexCacheUtils.get.should.have.been.calledWith(cache, key));
+
+      it('should not set data to cache', () => knexCacheUtils.set.should.not.been.called);
+    });
+
+    describe('when data is not cached', () => {
+      beforeEach(async () => {
+        knexCacheUtils.get.returns(undefined);
+        result = await commands.cache(cache, knexQuery, key);
+      });
+
+      it('should resolve with data', () => result.should.be.equal(data));
+
+      it('should get data from cache', () => knexCacheUtils.get.should.have.been.calledWith(cache, key));
+
+      it('should set data to cache', () => knexCacheUtils.set.should.have.been.calledWith(cache, key, data));
+    });
+  });
+
+  describe('#invalidate', () => {
+    let result;
+
+    describe('when data is already cached', () => {
+      let cachedData;
+
+      beforeEach(async () => {
+        cachedData = 'cachedData';
+        knexCacheUtils.get.returns(cachedData);
+        result = await commands.invalidate(cache, knexQuery, key, {exact: true});
+      });
+
+      it('should get data from cache', () => knexCacheUtils.get.should.have.been.calledWith(cache, key));
+
+      it('should unset data from cache', () => knexCacheUtils.unset.should.have.been.calledWith(cache, key, {exact: true}));
+
+      it('should resolve knex query', () => result.should.be.equal(data));
+    });
+
+    describe('when data is not cached', () => {
+      beforeEach(async () => {
+        knexCacheUtils.get.returns(undefined);
+        result = await commands.cache(cache, knexQuery, key);
+      });
+
+      it('should get data from cache', () => knexCacheUtils.get.should.have.been.calledWith(cache, key));
+
+      it('should not unset data from cache', () => knexCacheUtils.unset.should.not.have.been.called);
+
+      it('should resolve knex query', () => result.should.be.equal(data));
+    });
+  });
+})

--- a/test/unit/utils.test.js
+++ b/test/unit/utils.test.js
@@ -1,0 +1,138 @@
+'use strict';
+
+const utils = require('../../lib/utils');
+const { expect } = require('chai');
+
+describe('#utils', () => {
+  let cache;
+  let key;
+
+  beforeEach(() => {
+    cache = {
+      users: {
+        value: [{id: 0}, {id: 1}],
+        children: {
+          0: {
+            value: {id: 0},
+          },
+          1: {
+            value: {id: 1},
+          }
+        }
+      }
+    };
+  });
+
+  describe('#get', () => {
+    let result;
+
+    describe('when getting by simple key', () => {
+      beforeEach(async () => {
+        key = 'users';
+        result = utils.get(cache, key);
+      });
+
+      it('should get the expected value', () => result.should.be.equal(cache.users.value));
+    });
+
+    describe('when getting by nested key', () => {
+      beforeEach(async () => {
+        key = 'users.0';
+        result = utils.get(cache, key);
+      });
+
+      it('should get the expected value', () => result.should.be.equal(cache.users.children['0'].value));
+    });
+
+    describe('when getting by non chached key', () => {
+      beforeEach(async () => {
+        key = 'users.22';
+        result = utils.get(cache, key);
+      });
+
+      it('should return undefined', () => expect(result).to.be.undefined);
+    });
+  });
+
+  describe('#set', () => {
+    let data;
+
+    describe('when setting by simple key', () => {
+      describe('when key does not exist', () => {
+        beforeEach(async () => {
+          key = 'courses';
+          data = [{id: 22}];
+          utils.set(cache, key, data);
+        });
+  
+        it('should set value in the cache', () => cache.courses.value.should.be.equal(data));
+      });
+
+      describe('when key exists', () => {
+        beforeEach(async () => {
+          key = 'users';
+          data = [{id: 22}];
+          utils.set(cache, key, data);
+        });
+  
+        it('should set value in the cache', () => cache.users.value.should.be.equal(data));
+      });
+    });
+
+    describe('when setting by nested key', () => {
+      describe('when key does not exist', () => {
+        beforeEach(async () => {
+          key = 'users.22';
+          data = {id: 22};
+          utils.set(cache, key, data);
+        });
+  
+        it('should set value in the cache', () => cache.users.children['22'].value.should.be.equal(data));
+      });
+
+      describe('when key exists', () => {
+        beforeEach(async () => {
+          key = 'users.0';
+          data = {id: 22};
+          utils.set(cache, key, data);
+        });
+  
+        it('should set value in the cache', () => cache.users.children['0'].value.should.be.equal(data));
+      });
+    });
+
+  });
+
+  describe('#unset', () => {
+    describe('when unsetting by simple key', () => {
+      describe('when using exact parameter', () => {
+        beforeEach(() => {
+          key = 'users';
+          utils.unset(cache, key, {exact: true});
+        });
+
+        it('should remove the value', () => expect(cache.users.value).to.be.undefined);
+
+        it('should not remove the children', () => expect(cache.users.children).not.to.be.undefined);
+      });
+
+      describe('when not using exact parameter', () => {
+        beforeEach(() => {
+          key = 'users';
+          utils.unset(cache, key);
+        });
+  
+        it('should remove the value and the children', () => expect(cache.users).to.be.undefined);
+      });
+    });
+
+    describe('when unsetting by nested ket', () => {
+      beforeEach(() => {
+        key = 'users.0';
+        utils.unset(cache, key);
+      });
+
+      it('should remove the value', () => expect(cache.users.children['0']).to.be.undefined);
+    });
+  });
+})


### PR DESCRIPTION
- Nested keys: Now it's possible to add children keys separating keys by `.`. For example, `users.22` would be a child of `users`. This allows invalidating the parent key instead of invalidating all the children. The `exact: true` option should be explicitly set for invalidating only the parent.